### PR TITLE
link of oauth account to nomal account

### DIFF
--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -333,13 +333,22 @@ class Controller extends \Grav\Plugin\Login\Controller
                 'email'    => $data['email'],
                 'lang'     => $language,
             ]);
+            $user->save();
+        }
 
+        // Check linked user
+        $linked_username = $this->grav['config']->get('accounts.linked_accounts.'.$username);
+        if( $linked_username ){
+            $linked_user = User::load($linked_username);
+            if( $linked_user->exists() ){
+                $user = $linked_user;
+            }
+        }
+
+        // flag authenticated
+        if( $user->exists() ){
             $authenticated = true;
             $user->authenticated = true;
-            $user->save();
-
-        } else {
-            $authenticated = $user->authenticate($password);
         }
 
         // Store user in session

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -333,22 +333,27 @@ class Controller extends \Grav\Plugin\Login\Controller
                 'email'    => $data['email'],
                 'lang'     => $language,
             ]);
-            $user->save();
-        }
 
-        // Check linked user
-        $linked_username = $this->grav['config']->get('accounts.linked_accounts.'.$username);
-        if( $linked_username ){
-            $linked_user = User::load($linked_username);
-            if( $linked_user->exists() ){
-                $user = $linked_user;
-            }
-        }
-
-        // flag authenticated
-        if( $user->exists() ){
             $authenticated = true;
             $user->authenticated = true;
+            $user->save();
+
+        } else {
+            // An authenticate with id as password is trival
+            // However keep this to emphasis possible security issue for furture changes and keep the track 
+            $authenticated = $user->authenticate($password);
+        }
+
+        // Check liked user and chage current user with it if it's possible
+        if( $authenticated ){
+            $linked_username = $this->grav['config']->get('accounts.linked_accounts.'.$username);
+            if( $linked_username ){
+                $linked_user = User::load($linked_username);
+                if( $linked_user->exists() ){
+                    $user = $linked_user;
+                    $user->authenticated = true;
+                }
+            }
         }
 
         // Store user in session


### PR DESCRIPTION
This is for a feature to link an oauth account to a normal account.
There were many way what I could imagine for this.

Specially, Link informations could be stored in
1. user/accounts/each-normal-account-name.yaml
2. user/plugin/login-oauth.yaml
3. user/config/accounts.yaml

Each has own pros and cons, but I chosen (3) with some reasons (curious? :-) )

The format of accounts.yaml should be
```
linked_accounts:
    facebook:
        18918274928374928: any-normal-username
```

Also I removed `$user->authenticate($password)`, because `$user->authenticated = true` would be enough here and I think that there is no difference in security-wise.
( Frankly, it was hard to implement this while keeping `$user->authenticate($password)` :-) )

Any comments?