### PR TITLE
Facebook email scope

### DIFF
--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -47,7 +47,7 @@ class Controller extends \Grav\Plugin\Login\Controller
     protected $scopes = [
         'github'   => ['user'],
         'google'   => ['userinfo_email', 'userinfo_profile'],
-        'facebook' => ['public_profile']
+        'facebook' => ['public_profile','email']
     ];
 
     /**
@@ -209,7 +209,7 @@ class Controller extends \Grav\Plugin\Login\Controller
     {
         return $this->genericOAuthProvider(function () {
             // Send a request now that we have access token
-            $data = json_decode($this->service->request('/me'), true);
+            $data = json_decode($this->service->request('/me?fields=id,name,email'), true);
             $email = isset($data['email']) ? $data['email'] : '';
 
             $dataUser = [

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -47,7 +47,7 @@ class Controller extends \Grav\Plugin\Login\Controller
     protected $scopes = [
         'github'   => ['user'],
         'google'   => ['userinfo_email', 'userinfo_profile'],
-        'facebook' => ['public_profile','email']
+        'facebook' => ['public_profile']
     ];
 
     /**
@@ -68,6 +68,10 @@ class Controller extends \Grav\Plugin\Login\Controller
         // Use curl client instead of fopen stream
         if (extension_loaded('curl')) {
             $this->factory->setHttpClient(new CurlClient());
+        }
+        // Check configuration
+        if( $this->grav['config']->get('plugins.login-oauth.providers.Facebook.enable_email') ){
+          array_push( $this->scopes['facebook'] , 'email' );
         }
     }
 
@@ -209,7 +213,11 @@ class Controller extends \Grav\Plugin\Login\Controller
     {
         return $this->genericOAuthProvider(function () {
             // Send a request now that we have access token
-            $data = json_decode($this->service->request('/me?fields=id,name,email'), true);
+            $fields_query='';
+            if( $this->grav['config']->get('plugins.login-oauth.providers.Facebook.enable_email') ){
+              $fields_query = '?fields=id,name,email';
+            }
+            $data = json_decode($this->service->request('/me'.$fields_query), true);
             $email = isset($data['email']) ? $data['email'] : '';
 
             $dataUser = [
@@ -340,6 +348,11 @@ class Controller extends \Grav\Plugin\Login\Controller
 
         } else {
             $authenticated = $user->authenticate($password);
+            // Save new email if different.
+            if( $authenticated && $data['email'] != $user->get('email') ){
+                $user->set('email', $data['email'] );
+                $user->save();
+            }
         }
 
         // Store user in session

--- a/login-oauth.yaml
+++ b/login-oauth.yaml
@@ -4,6 +4,7 @@ built_in_css: true
 providers:
   Facebook:
     enabled: false
+    enable_email: false
     credentials:
       key:
       secret:


### PR DESCRIPTION
Hi, 

I'm requesting a PR for Facebook email scope.
This is to get email information while facebook oAuth.
This is a basic feature but also could be an important pre-logic for an another PR #9 

Before this commit, I had another commit [c6e94f9](https://github.com/qgp9/grav-plugin-login-oauth/commit/c6e95f976d6844179a18b04d16a8c1145a721843), there a facebook email scope was just hard coded.

Actually, I'm not very sure now whether an allowance of an email scope is a default or not in Facebook API. 
If yes, this hard code works smoothly but if not, un-notified users could get accident errors.
One can test this. ( because my app is already set for email so not easy to test ).

Anyway so, I implemented a dynamic method based on the plugin configuration for safety.
```
providers:
   Facebook:
     enabled: false
     enable_email: false
     credentials:
```

Now with this implementation, the plugin will get email info while oAuth login and save it.
Also, whenever an email differs from an old one ( specially, for an empty field of old users ), it will be update. 